### PR TITLE
Cast data as float before writing to db, and fix for -ve temperature values

### DIFF
--- a/SolarTracer.py
+++ b/SolarTracer.py
@@ -74,9 +74,9 @@ class SolarTracer:
 	    return 0
 
 	# read informational register
-	def readReg(self,register):
+	def readReg(self,register, signed=False):
 	    try:
-	            reading = self.instrument.read_register(register, 2, 4)
+	            reading = self.instrument.read_register(register, 2, 4, signed = signed)
 	            return reading
 	    except IOError:
 	            return -2

--- a/SolarTracer.py
+++ b/SolarTracer.py
@@ -97,7 +97,7 @@ class SolarTracer:
 	    except IOError as err:
 	    		return -2
 	    except ValueError:
-    			print "Could not convert data!"
+    			print("Could not convert data!")
     			return -3
 
 

--- a/logtracer.py
+++ b/logtracer.py
@@ -17,7 +17,7 @@ measurement_name = "solar"
 
 up = SolarTracer()
 if (up.connect() < 0):
-	print "Could not connect to the device"
+	print("Could not connect to the device")
 	exit -2
 
 # get timestamps
@@ -54,7 +54,7 @@ body_solar = [
     }
 ]
 
-print body_solar
+print(body_solar)
 
 # connect to influx
 ifclient = InfluxDBClient(ifhost,ifport,ifuser,ifpass,ifdb)

--- a/logtracer.py
+++ b/logtracer.py
@@ -37,19 +37,20 @@ body_solar = [
         "measurement": measurement_name,
         "time": timestamp,
         "fields": {
-            "PVvolt": up.readReg(PVvolt),
-            "PVamps": up.readReg(PVamps),
-            "PVwatt": PVwatt,
-            "PVkwh": up.readReg(PVkwhTotal),
-            "PVkwh2d": up.readReg(PVkwhToday),
-            "BAvolt": up.readReg(BAvolt),
-            "BAamps": up.readReg(BAamps),
-            "BAperc": up.readReg(BAperc),
-            "DCvolt": up.readReg(DCvolt),
-            "DCamps": up.readReg(DCamps),
-            "DCwatt": DCwatt,
-            "DCkwh": up.readReg(DCkwhTotal),
-            "DCkwh2d": up.readReg(DCkwhToday),
+            "PVvolt": float(up.readReg(PVvolt)),
+            "PVamps": float(up.readReg(PVamps)),
+            "PVwatt": float(PVwatt),
+            "PVkwh": float(up.readReg(PVkwhTotal)),
+            "PVkwh2d": float(up.readReg(PVkwhToday)),
+            "BAvolt": float(up.readReg(BAvolt)),
+            "BAamps": float(up.readReg(BAamps)),
+            "BAperc": float(up.readReg(BAperc)),
+            "DCvolt": float(up.readReg(DCvolt)),
+            "DCamps": float(up.readReg(DCamps)),
+            "DCwatt": float(DCwatt),
+            "DCkwh": float(up.readReg(DCkwhTotal)),
+            "DCkwh2d": float(up.readReg(DCkwhToday)),
+            "BAtemp": float(up.readReg(BAtemp))
         }
     }
 ]

--- a/logtracer.py
+++ b/logtracer.py
@@ -8,7 +8,7 @@ from SolarTracer import *
 
 # influx configuration - edit these
 ifuser = "grafana"
-ifpass = "solar"
+ifpass = "password"
 ifdb   = "solar"
 ifhost = "127.0.0.1"
 ifport = 8086
@@ -50,7 +50,7 @@ body_solar = [
             "DCwatt": float(DCwatt),
             "DCkwh": float(up.readReg(DCkwhTotal)),
             "DCkwh2d": float(up.readReg(DCkwhToday)),
-            "BAtemp": float(up.readReg(BAtemp))
+            "BAtemp": float(up.readReg(BAtemp, signed=True))
         }
     }
 ]


### PR DESCRIPTION
Hello,

Thanks for this code, I made some small changes that may useful to others:
1. I cast the measurements to floats to make the write consistent to InfluxDB.  If I recall, when I first tried this, if I wrote a whole number value, influx may set that column to an "int" and then break when a float was submitted later.
2. When it got cold, my temp sensor was trying to write a negative value, but the call to "miniimalmodbus" was an "unsigned" integer, so the value was wrong.  Added the ability to set a measurement to "signed" int.